### PR TITLE
Fix build for macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ ext_modules = [
     Pybind11Extension(
         name="micro_features_cpp",
         language="c++",
+        cxx_std=17,
         extra_compile_args=flags,
         sources=sorted([str(p) for p in sources] + [str(_DIR / "python.cpp")]),
         define_macros=[("VERSION_INFO", __version__)],


### PR DESCRIPTION
pybind11 doesn't like to compile mixed C/C++ codebases with Clang: C++17 features are used but setting `cxx_std=17` causes Clang to fail when compiling C source files, since `-std=c++17` isn't valid when building C.

I've worked around this problem by patching the distutils compiler at build time on macOS:

```bash
$ python -m build --wheel
...
Successfully built pymicro_features-1.0.0-cp311-cp311-macosx_14_0_arm64.whl
```